### PR TITLE
Feat/admin withdrawals

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'aasm'
 gem 'active_model_serializers', '~> 0.9.3'
 gem 'active_skin'
 gem 'activeadmin', github: 'activeadmin'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,8 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    aasm (5.0.1)
+      concurrent-ruby (~> 1.0)
     actioncable (5.2.1)
       actionpack (= 5.2.1)
       nio4r (~> 2.0)
@@ -424,6 +426,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aasm
   active_model_serializers (~> 0.9.3)
   active_skin
   activeadmin!

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -22,5 +22,4 @@ ActiveAdmin.register User do
     end
     f.actions
   end
-
 end

--- a/app/admin/withdrawals.rb
+++ b/app/admin/withdrawals.rb
@@ -1,0 +1,28 @@
+ActiveAdmin.register Withdrawal do
+  permit_params :amount, :user_id, :btc_address
+  actions :index, :show, :new, :create
+
+  index do
+    id_column
+    column :amount
+    column :user
+    column :btc_address
+    state_column :aasm_state
+    column :created_at
+    actions
+  end
+
+  filter :amount
+  filter :created_at
+  filter :user
+  filter :btc_address
+
+  form do |f|
+    f.inputs do
+      f.input :amount
+      f.input :user
+      f.input :btc_address
+    end
+    f.actions
+  end
+end

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -18,8 +18,13 @@ $panelHeaderBck: #002744;
 
 @import "active_skin";
 
+$pending-color: #FF9900;
+$confirmed-color: #08A510;
 
 // Overriding any non-variable SASS must be done after the fact.
 // For example, to change the default status-tag color:
 //
-//   .status_tag { background: #6090DB; }
+  .status_tag {
+  	&.pending { background: $pending-color; }
+  	&.confirmed { background: $confirmed-color; }
+ }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
     :recoverable, :rememberable, :validatable
 
   has_many :products
+  has_many :withdrawals
 
   def total_sales
     Product.joins(:invoice_products).where(user_id: id).sum(:price)

--- a/app/models/withdrawal.rb
+++ b/app/models/withdrawal.rb
@@ -10,7 +10,7 @@ class Withdrawal < ApplicationRecord
     end
   end
 
-  validates :amount, presence: true
+  validates :amount, :btc_address, presence: true
 
   belongs_to :user
 end
@@ -19,12 +19,13 @@ end
 #
 # Table name: withdrawals
 #
-#  id         :bigint(8)        not null, primary key
-#  user_id    :bigint(8)        not null
-#  amount     :bigint(8)
-#  aasm_state :string
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id          :bigint(8)        not null, primary key
+#  user_id     :bigint(8)        not null
+#  amount      :integer
+#  aasm_state  :string
+#  btc_address :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
 #
 # Indexes
 #

--- a/app/models/withdrawal.rb
+++ b/app/models/withdrawal.rb
@@ -1,0 +1,32 @@
+class Withdrawal < ApplicationRecord
+  include AASM
+
+  aasm do
+    state :pending, initial: true
+    state :confirmed
+
+    event :confirm do
+      transitions from: :pending, to: :confirmed
+    end
+  end
+
+  validates :amount, presence: true
+
+  belongs_to :user
+end
+
+# == Schema Information
+#
+# Table name: withdrawals
+#
+#  id         :bigint(8)        not null, primary key
+#  user_id    :bigint(8)        not null
+#  amount     :bigint(8)
+#  aasm_state :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_withdrawals_on_user_id  (user_id)
+#

--- a/db/migrate/20181224120350_create_withdrawals.rb
+++ b/db/migrate/20181224120350_create_withdrawals.rb
@@ -1,0 +1,10 @@
+class CreateWithdrawals < ActiveRecord::Migration[5.2]
+  def change
+    create_table :withdrawals do |t|
+    	t.references :user, null: false
+    	t.bigint :amount
+    	t.string :aasm_state
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20181224120350_create_withdrawals.rb
+++ b/db/migrate/20181224120350_create_withdrawals.rb
@@ -2,8 +2,9 @@ class CreateWithdrawals < ActiveRecord::Migration[5.2]
   def change
     create_table :withdrawals do |t|
     	t.references :user, null: false
-    	t.bigint :amount
+    	t.integer :amount
     	t.string :aasm_state
+    	t.string :btc_address
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -107,8 +107,9 @@ ActiveRecord::Schema.define(version: 2018_12_24_120350) do
 
   create_table "withdrawals", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.bigint "amount"
+    t.integer "amount"
     t.string "aasm_state"
+    t.string "btc_address"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_withdrawals_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_18_172041) do
+ActiveRecord::Schema.define(version: 2018_12_24_120350) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -103,6 +103,15 @@ ActiveRecord::Schema.define(version: 2018_12_18_172041) do
     t.string "name", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
+
+  create_table "withdrawals", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "amount"
+    t.string "aasm_state"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_withdrawals_on_user_id"
   end
 
   add_foreign_key "products", "users"

--- a/spec/factories/withdrawals.rb
+++ b/spec/factories/withdrawals.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :withdrawal do
+    amount 100
+    association :user, factory: :user
+  end
+end

--- a/spec/factories/withdrawals.rb
+++ b/spec/factories/withdrawals.rb
@@ -1,6 +1,7 @@
 FactoryGirl.define do
   factory :withdrawal do
     amount 100
+    btc_address '0x1234567890'
     association :user, factory: :user
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe User, type: :model do
   describe "validations" do
     it { should have_many(:products) }
+    it { should have_many(:withdrawals) }
   end
 
   describe "#total_sales" do

--- a/spec/models/withdrawal_spec.rb
+++ b/spec/models/withdrawal_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Withdrawal, type: :model do
+  it { should validate_presence_of(:amount) }
+  it { should belong_to(:user) }
+
+  it 'starts with default "pending" state' do
+    withdrawal = create(:withdrawal)
+    expect(withdrawal.aasm.current_state).to eq(:pending)
+  end
+end

--- a/spec/models/withdrawal_spec.rb
+++ b/spec/models/withdrawal_spec.rb
@@ -3,9 +3,14 @@ require 'rails_helper'
 RSpec.describe Withdrawal, type: :model do
   it { should validate_presence_of(:amount) }
   it { should belong_to(:user) }
+  let(:withdrawal) { create(:withdrawal) }
 
   it 'starts with default "pending" state' do
-    withdrawal = create(:withdrawal)
     expect(withdrawal.aasm.current_state).to eq(:pending)
+  end
+
+  it 'changes state to "confirmed" correctly' do
+    withdrawal.confirm
+    expect(withdrawal.aasm.current_state).to eq(:confirmed)
   end
 end


### PR DESCRIPTION
- Creación de modelo Withdrawal. Los atributos mas importantes son "amount", "created_at" (que se muestra como "Fecha de emisión") y aasm_state (que se muestra como "Estado").
- El modelo esta asociado a un usuario mediante la columna user_id
- El atributo se maneja mediante la gema AASM y existen dos posibles estados: "pending" y "confirmed". 
- "pending" es cuando el retiro se crea y "confirmed" cuando se crea la transacción correspondiente a nivel del blockchain de BTC.
- ademas se integró este modelo con ActiveAdmin