### PR TITLE
Feat/user withdrawals

### DIFF
--- a/app/controllers/withdrawals_controller.rb
+++ b/app/controllers/withdrawals_controller.rb
@@ -1,6 +1,12 @@
 class WithdrawalsController < ApplicationController
   before_action :authenticate_user!
 
+  def index
+    @withdrawals = current_user.withdrawals
+    @total_confirmed = current_user.total_confirmed_withdrawals
+    @total_pending = current_user.total_pending_withdrawals
+  end
+
   def new
     @withdrawal = current_user.withdrawals.new
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,7 @@ class User < ApplicationRecord
   end
 
   def total_withdrawals
-    withdrawals.sum(:amount)
+    withdrawals.where.not(aasm_state: :rejected).sum(:amount)
   end
 
   def withdrawable_amount

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,14 @@ class User < ApplicationRecord
     withdrawals.where.not(aasm_state: :rejected).sum(:amount)
   end
 
+  def total_pending_withdrawals
+    withdrawals.where(aasm_state: :pending).sum(:amount)
+  end
+
+  def total_confirmed_withdrawals
+    withdrawals.where(aasm_state: :confirmed).sum(:amount)
+  end
+
   def withdrawable_amount
     total_sales - total_withdrawals
   end

--- a/app/models/withdrawal.rb
+++ b/app/models/withdrawal.rb
@@ -3,17 +3,23 @@ class Withdrawal < ApplicationRecord
 
   aasm do
     state :pending, initial: true
-    state :confirmed
+    state :confirmed, :rejected
 
     event :confirm do
       transitions from: :pending, to: :confirmed
+    end
+
+    event :reject do
+      transitions from: :pending, to: :rejected
     end
   end
 
   validates :amount, :btc_address, presence: true
   validates :amount, numericality: { greater_than: 0, only_integer: true }
-  validate :amount_cant_be_greater_than_user_withdrawable_amount
+  validate :amount_cant_be_greater_than_user_withdrawable_amount, on: :create
   validate :address_is_valid_btc_address
+
+  belongs_to :user
 
   def amount_cant_be_greater_than_user_withdrawable_amount
     if amount && amount > user.withdrawable_amount
@@ -26,8 +32,6 @@ class Withdrawal < ApplicationRecord
       errors.add(:btc_address, 'BTC address must be a valid one')
     end
   end
-
-  belongs_to :user
 end
 
 # == Schema Information

--- a/app/views/withdrawals/index.html.erb
+++ b/app/views/withdrawals/index.html.erb
@@ -1,0 +1,28 @@
+<div id="products-index-table">
+	<h1> Mis Retiros </h1>
+	<h3> Total retirado confirmado: <%= @total_confirmed %> </h3>
+	<h3> Total retirado pendiente: <%= @total_pending %> </h3>
+
+	<table>
+		<thead>
+	    <tr>
+	      <th> Cantidad </th>
+	      <th> Estado </th>
+	      <th> Dirección BTC </th>
+	      <th> Actualizado en </th>
+	      <th> Solicitado en </th>
+	    </tr>
+		</thead>
+		<tbody>
+			<% @withdrawals.each do |withdrawal| %>
+				<tr>
+					<td> <%= withdrawal.amount %> </td>
+					<td> <%= withdrawal.aasm.current_state.capitalize %> </td>
+					<td> <%= withdrawal.btc_address %> </td>
+					<td> <%= withdrawal.updated_at.strftime("%d/%m/%Y %H:%M") %> </td>
+					<td> <%= withdrawal.created_at.strftime("%d/%m/%Y %H:%M") %> </td>
+				</tr>
+			<% end %>
+		</tbody>
+	</table>
+</div>

--- a/spec/controllers/withdrawals_controller_spec.rb
+++ b/spec/controllers/withdrawals_controller_spec.rb
@@ -11,6 +11,45 @@ RSpec.describe WithdrawalsController, type: :controller do
     post action, params: params, xhr: true
   end
 
+  describe 'GET #index' do
+    context 'unauthenticated user' do
+      it 'redirects to sign up form' do
+        get :index
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context 'authenticated user' do
+      let(:user) { create_user_with_invoice(100, 100, 5000) }
+      before do
+        create(:withdrawal, amount: 500, user: user)
+        create(:withdrawal, amount: 500, user: user).confirm!
+        create(:withdrawal, amount: 500, user: user).reject!
+        mock_authentication
+      end
+
+      it 'assigns list with user withdrawals' do
+        get :index
+        expect(assigns(:withdrawals)).to have(3).items
+      end
+
+      it 'assigns total pending sum' do
+        get :index
+        expect(assigns(:total_pending)).to be_an(Integer)
+      end
+
+      it 'assigns total confirmed sum' do
+        get :index
+        expect(assigns(:total_confirmed)).to be_an(Integer)
+      end
+
+      it 'returns correct "index" view' do
+        get :index
+        expect(response).to render_template('withdrawals/index')
+      end
+    end
+  end
+
   describe 'GET #new' do
     context 'unauthenticated user' do
       it 'returns 401 unauthorized' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe User, type: :model do
       it { expect(user.total_withdrawals).to be(0) }
     end
 
-    context "user has 1 pending withdrawal" do
+    context "user has 1 withdrawal" do
       let(:user) { create_user_with_invoice(100, 100, 5000) }
       before { create(:withdrawal, amount: 500, user: user) }
 
@@ -124,6 +124,54 @@ RSpec.describe User, type: :model do
       end
 
       it { expect(user.total_withdrawals).to be(1000) }
+    end
+  end
+
+  describe "#total_pending_withdrawals" do
+    context "user has no pending withdrawals" do
+      let(:user) { create_user_with_invoice(100, 100, 5000) }
+      before do
+        create(:withdrawal, amount: 500, user: user).confirm!
+        create(:withdrawal, amount: 500, user: user).reject!
+      end
+
+      it { expect(user.total_pending_withdrawals).to be(0) }
+    end
+
+    context "user has pending withdrawals" do
+      let(:user) { create_user_with_invoice(100, 100, 5000) }
+      before do
+        create(:withdrawal, amount: 500, user: user)
+        create(:withdrawal, amount: 500, user: user)
+        create(:withdrawal, amount: 500, user: user).confirm!
+        create(:withdrawal, amount: 500, user: user).reject!
+      end
+
+      it { expect(user.total_pending_withdrawals).to be(1000) }
+    end
+  end
+
+  describe "#total_confirmed_withdrawals" do
+    context "user has no confirmed withdrawals" do
+      let(:user) { create_user_with_invoice(100, 100, 5000) }
+      before do
+        create(:withdrawal, amount: 500, user: user)
+        create(:withdrawal, amount: 500, user: user).reject!
+      end
+
+      it { expect(user.total_confirmed_withdrawals).to be(0) }
+    end
+
+    context "user has confirmed withdrawals" do
+      let(:user) { create_user_with_invoice(100, 100, 5000) }
+      before do
+        create(:withdrawal, amount: 500, user: user)
+        create(:withdrawal, amount: 500, user: user).confirm!
+        create(:withdrawal, amount: 500, user: user).confirm!
+        create(:withdrawal, amount: 500, user: user).reject!
+      end
+
+      it { expect(user.total_confirmed_withdrawals).to be(1000) }
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe User, type: :model do
       it { expect(user.total_withdrawals).to be(0) }
     end
 
-    context "user has 1 withdrawal" do
+    context "user has 1 pending withdrawal" do
       let(:user) { create_user_with_invoice(100, 100, 5000) }
       before { create(:withdrawal, amount: 500, user: user) }
 
@@ -113,6 +113,17 @@ RSpec.describe User, type: :model do
       end
 
       it { expect(user.total_withdrawals).to be(2500) }
+    end
+
+    context "user has 3 withdrawals with different states" do
+      let(:user) { create_user_with_invoice(100, 100, 5000) }
+      before do
+        create(:withdrawal, amount: 500, user: user)
+        create(:withdrawal, amount: 500, user: user).confirm!
+        create(:withdrawal, amount: 500, user: user).reject!
+      end
+
+      it { expect(user.total_withdrawals).to be(1000) }
     end
   end
 

--- a/spec/models/withdrawal_spec.rb
+++ b/spec/models/withdrawal_spec.rb
@@ -117,5 +117,10 @@ RSpec.describe Withdrawal, type: :model do
       withdrawal.confirm
       expect(withdrawal.aasm.current_state).to eq(:confirmed)
     end
+
+    it 'changes state to "rejected" correctly' do
+      withdrawal.reject
+      expect(withdrawal.aasm.current_state).to eq(:rejected)
+    end
   end
 end


### PR DESCRIPTION
Agregar estado "Rejected" al modelo Withdrawals. En base a eso, total_withdrawals ahora se calcula como la suma de todos los Withdrawals de un usuario, menos los rechazados. 

Agregar validación que revise que la cantidad retirada sea menor o igual que withdrawable_amount.

Crear un index de retiros para que el usuario pueda ver cuántos tiene pending, rejected y confirmed.