### PR TITLE
Fix/invoice product price

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -1,8 +1,13 @@
 class Invoice < ApplicationRecord
   validates :clp, :memo, :payment_request, :r_hash, :amount, presence: true
+  validates :clp, :amount, numericality: { greater_than: 0 }
 
   has_many :invoice_products
   has_many :products, through: :invoice_products
+
+  def satoshi_clp_ratio
+    amount.to_f / clp
+  end
 end
 
 # == Schema Information

--- a/app/models/invoice_product.rb
+++ b/app/models/invoice_product.rb
@@ -1,17 +1,43 @@
 class InvoiceProduct < ApplicationRecord
+  validates :product_price, presence: true
+
   belongs_to :product
   belongs_to :invoice
+
+  before_validation { fix_product_price }
+
+  def fix_product_price
+    fetch_product
+    fetch_invoice
+    return if @product.nil? || @invoice.nil?
+    self.product_price = product_price_initial_calc
+  end
+
+  def fetch_product
+    return unless product_id
+    @product = Product.find(product_id)
+  end
+
+  def fetch_invoice
+    return unless invoice_id
+    @invoice = Invoice.find(invoice_id)
+  end
+
+  def product_price_initial_calc
+    @product.price * @invoice.satoshi_clp_ratio
+  end
 end
 
 # == Schema Information
 #
 # Table name: invoice_products
 #
-#  id         :bigint(8)        not null, primary key
-#  product_id :bigint(8)        not null
-#  invoice_id :bigint(8)        not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id            :bigint(8)        not null, primary key
+#  product_id    :bigint(8)        not null
+#  invoice_id    :bigint(8)        not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  product_price :integer          not null
 #
 # Indexes
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,7 @@ class User < ApplicationRecord
     Product.where(user_id: id)
            .joins(invoice_products: :invoice)
            .where('invoices.settled=true')
-           .sum('floor(price * (amount::numeric / clp))::integer')
+           .sum('invoice_products.product_price')
   end
 
   def total_withdrawals

--- a/app/views/products/_row.html.erb
+++ b/app/views/products/_row.html.erb
@@ -3,7 +3,7 @@
 	<td> <%= product.price %> </td>
 	<td> <%= product.active %> </td>
 	<td> <%= product.invoice_products.count %> </td>
-	<td> <%= product.invoice_products.count * product.price %> </td>
+	<td> <%= product.invoice_products.sum(:product_price) %> </td>
 	<td class="products-index__table-actions">
 		<button
 			type="button"

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -36,18 +36,18 @@
 			</div>
 		</div>
 
-		<h4 class="products-index__total-sales"> Total de ventas: <%= current_user.total_sales %> </h4>
-		<h4 class="products-index__withdrawable-amount"> Monto disponible para retiro: <%= @withdrawable_amount %> </h4>
+		<h4 class="products-index__total-sales"> Total de ventas: <%= current_user.total_sales %> (Satoshis) </h4>
+		<h4 class="products-index__withdrawable-amount"> Monto disponible para retiro: <%= @withdrawable_amount %> (Satoshis) </h4>
 
 		<% if @products.length > 0 %>
 			<table class="products-index__table">
 				<thead>
 			    <tr>
 			      <th class="products-index__table-header"> Nombre </th>
-			      <th class="products-index__table-header"> Precio </th>
+			      <th class="products-index__table-header"> Precio (CLP) </th>
 			      <th class="products-index__table-header"> Active </th>
 			      <th class="products-index__table-header"> Ventas (UN) </th>
-			      <th class="products-index__table-header"> Ventas (CLP) </th>
+			      <th class="products-index__table-header"> Ventas (Satoshis) </th>
 			      <th class="products-index__table-header products-index__table-header--fixed-width"> Acciones </th>
 			    </tr>
 				</thead>

--- a/db/migrate/20190109120350_add_product_price_to_invoice_product.rb
+++ b/db/migrate/20190109120350_add_product_price_to_invoice_product.rb
@@ -1,0 +1,16 @@
+class AddProductPriceToInvoiceProduct < ActiveRecord::Migration[5.2]
+  def up
+  	add_column :invoice_products, :product_price, :integer
+  	Product.all.each do |product|
+  		product.invoice_products.each do |invoice_product|
+        invoice = invoice_product.invoice
+  			invoice_product.update(product_price: product.price * invoice.satoshi_clp_ratio)
+  		end
+  	end
+  	change_column_null :invoice_products, :product_price, false
+  end
+
+  def down
+  	remove_column :invoice_products, :product_price
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_02_122926) do
+ActiveRecord::Schema.define(version: 2019_01_09_120350) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -67,6 +67,7 @@ ActiveRecord::Schema.define(version: 2019_01_02_122926) do
     t.bigint "invoice_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "product_price", null: false
     t.index ["invoice_id"], name: "index_invoice_products_on_invoice_id"
     t.index ["product_id"], name: "index_invoice_products_on_product_id"
   end

--- a/spec/models/invoice_product_spec.rb
+++ b/spec/models/invoice_product_spec.rb
@@ -4,10 +4,21 @@ RSpec.describe InvoiceProduct, type: :model do
   describe "validations" do
     it { should belong_to(:product) }
     it { should belong_to(:invoice) }
+    it { should validate_presence_of(:product_price) }
 
     it 'has a valid factory' do
       invoice_product = build(:invoice_product)
       expect(invoice_product).to be_valid
+    end
+  end
+
+  describe "before validations 'fix_product_price' hook" do
+    let (:invoice) { create(:invoice) }
+    let (:product) { create(:product) }
+    let (:invoice_product) { create(:invoice_product, invoice: invoice, product: product) }
+
+    it 'saves invoice product with correct price' do
+      expect(invoice_product.product_price).to eq(invoice_product.product_price_initial_calc)
     end
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -10,4 +10,18 @@ RSpec.describe Invoice, type: :model do
     it { should have_many(:invoice_products) }
     it { should have_many(:products) }
   end
+
+  describe "satoshi_clp_ratio" do
+    describe "case integer" do
+      let(:invoice) { create(:invoice, clp: 100, amount: 500) }
+
+      it { expect(invoice.satoshi_clp_ratio).to eq(5) }
+    end
+
+    describe "case float" do
+      let(:invoice) { create(:invoice, clp: 500, amount: 100) }
+
+      it { expect(invoice.satoshi_clp_ratio).to eq(0.2) }
+    end
+  end
 end


### PR DESCRIPTION
Ahora se fija en el modelo InvoiceProduct el precio del producto (product_price) al momento de crear el invoice_product (con un before save validation). Para eso se calcula el precio de un clp en satoshi, y se multiplica por el precio del producto (que se guarda en clp). De esta forma, para calcular los ingresos de un vendedor la cosa se simplifica, basta con sumar el atributo product_price para cada invoice_product.

Ademas, se hacen cambios a nivel de front end para mostrar las columnas con unidades correspondientes:

<img width="1439" alt="screen shot 2019-01-09 at 5 34 25 pm" src="https://user-images.githubusercontent.com/20782578/50926864-d8d1e500-1434-11e9-97fb-ec7f46d4588f.png">
