### PR TITLE
Fix/rebase from production

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,6 +21,7 @@
 @import 'registrations';
 @import 'welcome';
 @import 'withdrawals';
+@import 'vue-flash-message/dist/vue-flash-message.min.css';
 
 html,
 body {

--- a/app/javascript/components/product.vue
+++ b/app/javascript/components/product.vue
@@ -1,9 +1,6 @@
 <template>
-  <v-touch class="product-list__product"
-           v-on:swipeleft="decrementProduct(product); message('decrement', product)"
-           v-on:swiperight="incrementProduct(product); message('increment', product)">
-    <img class="product__image" :src="product.image_url"
-         @click="incrementProduct(product); message('increment', product)">
+  <v-touch class="product-list__product">
+    <img class="product__image" :src="product.image_url" @click="incrementProduct(product); message('increment', product)">
     <span class="product__price">${{product.price}}</span>
   </v-touch>
 </template>
@@ -19,7 +16,6 @@
     computed: {},
     methods: {
       ...mapActions([
-        'decrementProduct',
         'incrementProduct',
       ]),
       message(action, product) {


### PR DESCRIPTION
Hace un tiempo se importaba todo lo relacionado a css mediante la sentencia "require_tree". No obstante, concluimos que esta práctica no es ideal, ya que es muy fácil perder noción de las dependencias. Además, teníamos problemas con el css de active admin que sobre escribía css "propio" de la aplicación. Por estas dos razones se dejó de importar usando "require_tree". Ahora se importa todo explícitamente. Al hacer ese cambio nos olvidamos de importar el css default que ocupa vue-flash-message. Ahora se agregó.

Otro cambio de este commit es que incorpora los cambios de Camilo, los cuales arreglan la función de scroll cuando se muestran los productos en venta. Estos cambios se perdieron (se desconoce la razón) y no se pudieron encontrar en ninguna rama (de hecho el commit aparece sin rama). Por ende, se re agregaron como un commit nuevo.