### PR TITLE
fix(priceshash): cast product id to integer and use named arguments

### DIFF
--- a/app/commands/create_invoice.rb
+++ b/app/commands/create_invoice.rb
@@ -27,7 +27,7 @@ class CreateInvoice < PowerTypes::Command.new(:memo, :products_hash)
   end
 
   def prices_hash
-    @prices_hash ||= GetPricesHash.for(@products_hash)
+    @prices_hash ||= GetPricesHash.for(products_hash: @products_hash)
   end
 
   def lightning_network_client

--- a/app/commands/create_invoice_products.rb
+++ b/app/commands/create_invoice_products.rb
@@ -11,7 +11,7 @@ class CreateInvoiceProducts < PowerTypes::Command.new(:invoice, :prices_hash, :p
 
   def invoice_products_data
     @products_hash.each do |product_id, data|
-      add_product(product_id, data['amount'])
+      add_product(product_id.to_i, data['amount'])
     end
     invoice_products
   end

--- a/app/commands/get_prices_hash.rb
+++ b/app/commands/get_prices_hash.rb
@@ -12,7 +12,7 @@ class GetPricesHash < PowerTypes::Command.new(:products_hash)
 
   def check_prices!
     @products_hash.each do |id, data|
-      if data['price'] != prices_hash[id]
+      if data['price'] != prices_hash[id.to_i]
         raise 'Prices in request are no longer available'
       end
     end

--- a/spec/commands/create_invoice_products_spec.rb
+++ b/spec/commands/create_invoice_products_spec.rb
@@ -18,7 +18,7 @@ describe CreateInvoiceProducts do
 
   context 'with 1 product' do
     let(:invoice) { create(:invoice) }
-    let(:products_hash) { { product_a.id => { 'amount' => 1, 'price' => 1000 } } }
+    let(:products_hash) { { product_a.id.to_s => { 'amount' => 1, 'price' => 1000 } } }
     let(:invoice_product) { invoice.invoice_products.first }
     before { perform }
 
@@ -37,7 +37,7 @@ describe CreateInvoiceProducts do
 
   context 'with more than 1 equal products' do
     let(:invoice) { create(:invoice, clp: 3000, amount: 300000) }
-    let(:products_hash) { { product_a.id => { 'amount' => 3, 'price' => 1000 } } }
+    let(:products_hash) { { product_a.id.to_s => { 'amount' => 3, 'price' => 1000 } } }
     before { perform }
 
     it 'creates correct amount of invoice products' do
@@ -57,8 +57,8 @@ describe CreateInvoiceProducts do
     let(:invoice) { create(:invoice, clp: 5000, amount: 500000) }
     let(:products_hash) do
       {
-        product_a.id => { 'amount' => 3, 'price' => 1000 },
-        product_b.id => { 'amount' => 2, 'price' => 1000 }
+        product_a.id.to_s => { 'amount' => 3, 'price' => 1000 },
+        product_b.id.to_s => { 'amount' => 2, 'price' => 1000 }
       }
     end
     before { perform }
@@ -81,7 +81,7 @@ describe CreateInvoiceProducts do
     let(:invoice) { create(:invoice) }
 
     context 'it uses old structure of products hash' do
-      let(:products_hash) { { product_a.id => 4 } }
+      let(:products_hash) { { product_a.id.to_s => 4 } }
 
       it 'raises error' do
         expect { perform }.to raise_error(TypeError)
@@ -91,7 +91,7 @@ describe CreateInvoiceProducts do
 
   context 'invalid prices hash' do
     let(:invoice) { create(:invoice) }
-    let(:products_hash) { { product_a.id => { 'amount' => 4, 'price' => 1000 } } }
+    let(:products_hash) { { product_a.id.to_s => { 'amount' => 4, 'price' => 1000 } } }
 
     context 'it uses list of hashes as prices hash' do
       let(:prices_hash) { [{ product_a.id => 1000 }, { product_b.id => 1000 }] }
@@ -104,7 +104,7 @@ describe CreateInvoiceProducts do
 
   context 'with no stock' do
     let(:invoice) { create(:invoice) }
-    let(:products_hash) { { product_a.id => { 'amount' => 4, 'price' => 1000 } } }
+    let(:products_hash) { { product_a.id.to_s => { 'amount' => 4, 'price' => 1000 } } }
     before { user_product_a.update(stock: 3) }
 
     it 'does not create any of the invoice products' do

--- a/spec/commands/create_invoice_spec.rb
+++ b/spec/commands/create_invoice_spec.rb
@@ -20,8 +20,8 @@ describe CreateInvoice do
 
   let(:products_hash) do
     {
-      product_a.id => { 'amount' => 3, 'price' => 1000 },
-      product_b.id => { 'amount' => 2, 'price' => 1000 }
+      product_a.id.to_s => { 'amount' => 3, 'price' => 1000 },
+      product_b.id.to_s => { 'amount' => 2, 'price' => 1000 }
     }
   end
 
@@ -113,7 +113,7 @@ describe CreateInvoice do
     perform
     expect(GetPricesHash)
       .to have_received(:for)
-      .with(products_hash)
+      .with(products_hash: products_hash)
   end
 
   context 'with 0 satoshis' do

--- a/spec/commands/get_prices_hash_spec.rb
+++ b/spec/commands/get_prices_hash_spec.rb
@@ -8,8 +8,8 @@ describe GetPricesHash do
   let!(:user_product_b) { create(:user_product, user: user, product: product_b, price: 2000) }
   let(:products_hash) do
     {
-      product_a.id => { 'amount' => 3, 'price' => 1000 },
-      product_b.id => { 'amount' => 2, 'price' => 2000 }
+      product_a.id.to_s => { 'amount' => 3, 'price' => 1000 },
+      product_b.id.to_s => { 'amount' => 2, 'price' => 2000 }
     }
   end
 


### PR DESCRIPTION
Los "named arguments" son para cuando se llama al comando con la sintaxis Command.for(named_arg: arg).

Lo otro es que el request de la app en Vue manda los ids como strings, pero el backend los maneja como integers, por ende hay que hacer la conversión correspondiente.