### PR TITLE
fix(ui/Product): make product selectable by tapping on image container

### DIFF
--- a/app/javascript/components/product.vue
+++ b/app/javascript/components/product.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-touch class="product-list__product">
-    <img class="product__image" :src="product.image_url" @click="incrementProduct(product); message('increment', product)">
+  <v-touch class="product-list__product" @tap="incrementProduct(product); message('increment', product)">
+    <img class="product__image" :src="product.image_url">
     <span class="product__price">${{product.price}}</span>
   </v-touch>
 </template>


### PR DESCRIPTION
## Descripción

Los productos no se agregan al carro si hacías click encima del precio, por ejemplo

## Cambios

Se escucha el evento `@tap` en el contenedor de la imagen y el precio