### PR TITLE
Fix error handling

### DIFF
--- a/app/controllers/concerns/api_error_concern.rb
+++ b/app/controllers/concerns/api_error_concern.rb
@@ -8,25 +8,33 @@ module ApiErrorConcern
       respond_api_error(:internal_server_error, message: "server_error",
                                                 type: exception.class.to_s,
                                                 detail: exception.message)
-      Raven.capture_exception(exc)
+      Raven.capture_exception(exception)
     end
 
     rescue_from "ActiveRecord::RecordNotFound" do |exception|
       respond_api_error(:not_found, message: "record_not_found",
                                     detail: exception.message)
-      Raven.capture_exception(exc)
+      Raven.capture_exception(exception)
     end
 
     rescue_from "ActiveModel::ForbiddenAttributesError" do |exception|
       respond_api_error(:bad_request, message: "protected_attributes",
                                       detail: exception.message)
-      Raven.capture_exception(exc)
+      Raven.capture_exception(exception)
     end
 
     rescue_from "ActiveRecord::RecordInvalid" do |exception|
       respond_api_error(:bad_request, message: "invalid_attributes",
                                       errors: exception.record.errors)
-      Raven.capture_exception(exc)
+      Raven.capture_exception(exception)
+    end
+
+    rescue_from 'ActionController::ParameterMissing' do |exception|
+      respond_api_error(:bad_request, msg: 'missing_parameters', errors: exception.message)
+    end
+
+    rescue_from 'ActionController::UnknownFormat' do
+      render json: { message: 'format_not_supported' }, status: :bad_request
     end
   end
 

--- a/spec/controllers/api/v1/base_controller_spec.rb
+++ b/spec/controllers/api/v1/base_controller_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+describe Api::V1::BaseController, type: :controller do
+  it_behaves_like "exception_handler_controller"
+end

--- a/spec/support/shared_examples/api_error_concern.rb
+++ b/spec/support/shared_examples/api_error_concern.rb
@@ -1,0 +1,44 @@
+shared_examples "exception_handler_controller" do
+  context "with missing required parameter" do
+    controller do
+      def index
+        params.require(:missing_param)
+      end
+    end
+
+    it "responds 400" do
+      get :index, format: :json
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+
+  context "when controller raises ActiveRecord::RecordNotFound" do
+    controller do
+      def index
+        raise ActiveRecord::RecordNotFound
+      end
+    end
+
+    it "responds 404" do
+      get :index, format: :json
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context "when controller raises ActiveRecord::RecordInvalid" do
+    controller do
+      class InvalidRecord
+        include ActiveModel::Model
+      end
+
+      def index
+        raise ActiveRecord::RecordInvalid.new(InvalidRecord.new)
+      end
+    end
+
+    it "responds 400" do
+      get :index, format: :json
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+end


### PR DESCRIPTION
## Descripción

Los errores de Sentry se están logueando, pero con un error adicional ya que al manejar la excepción se usaba un nombre incorrecto de la variable del bloque

## Cambios
 - Se arregla el nombre de la variable
 - Se agregan nuevos casos de manejo de excepciones en `ApiErrorConcern`
 - Se agregan specs para testear los controllers que incluyan a `ApiErrorConcern` y se agrega un spec para testear que `BaseController` maneje correctamente estas excepciones