### PR TITLE
fix(BudaClient): fix missing nonce on auth requests

### DIFF
--- a/app/clients/buda_client.rb
+++ b/app/clients/buda_client.rb
@@ -49,7 +49,7 @@ class BudaClient
   def headers(request_type, path, payload = nil)
     {
       'X-SBTC-APIKEY' => API_KEY,
-      'X-SBTC-NONCE' => nonce,
+      'X-SBTC-NONCE' => generate_nonce,
       'X-SBTC-SIGNATURE' => request_signature(request_type, path, payload),
       'Content-Type' => 'application/json'
     }


### PR DESCRIPTION
## Descripción

Se arregla una referencia obsoleta al método `nonce` que se renombró a `generate_nonce` y se actualizan los specs para ser más estrictos